### PR TITLE
Set the python path for runserver

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,3 +1,11 @@
+2.2 (2024-12-19)
+++++++++++++++++
+
+* Add the directory to the Python path
+  if the settings module from the configuration file
+  is the same as it is in the environment.
+  This allows ``django runserver`` to work.
+
 2.1 (2024-12-16)
 ++++++++++++++++
 

--- a/django_cmd_test.py
+++ b/django_cmd_test.py
@@ -1,9 +1,26 @@
 import os
 import subprocess
+from contextlib import contextmanager
+
+import pytest
 
 from django_cmd import main
 
 
+@contextmanager
+def restore_environ(keys):
+    """Restore the given environment keys after the context."""
+    missing = {key for key in keys if key not in os.environ}
+    saved = {key: os.environ[key] for key in keys if key in os.environ}
+    yield
+    for key in missing:
+        if key in os.environ:
+            del os.environ[key]
+    for key, value in saved.items():
+        os.environ[key] = value
+
+
+@restore_environ(["DJANGO_SETTINGS_MODULE"])
 def test_main_passthru(monkeypatch, mocker, tmpdir):
     """It shouldn't change a given DJANGO_SETTINGS_MODULE."""
     cmd = mocker.patch("django_cmd.execute_from_command_line")
@@ -16,6 +33,7 @@ def test_main_passthru(monkeypatch, mocker, tmpdir):
     assert cmd.called
 
 
+@restore_environ(["DJANGO_SETTINGS_MODULE"])
 def test_main_from_pyproject_toml(mocker, tmpdir):
     """Read settings module path from toml file."""
     cmd = mocker.patch("django_cmd.execute_from_command_line")
@@ -25,9 +43,9 @@ def test_main_from_pyproject_toml(mocker, tmpdir):
     main()
     assert os.environ.get("DJANGO_SETTINGS_MODULE") == "ball.yarn"
     assert cmd.called
-    del os.environ["DJANGO_SETTINGS_MODULE"]
 
 
+@restore_environ(["DJANGO_SETTINGS_MODULE"])
 def test_main_from_pyproject_toml_nosetting(mocker, tmpdir):
     """Handle if there's a tool.django section with no settings module."""
     cmd = mocker.patch("django_cmd.execute_from_command_line")
@@ -39,6 +57,7 @@ def test_main_from_pyproject_toml_nosetting(mocker, tmpdir):
     assert cmd.called
 
 
+@restore_environ(["DJANGO_SETTINGS_MODULE"])
 def test_main_from_pyproject_toml_nodjango(mocker, tmpdir):
     """Handle if there's no tool.django section."""
     cmd = mocker.patch("django_cmd.execute_from_command_line")
@@ -50,6 +69,7 @@ def test_main_from_pyproject_toml_nodjango(mocker, tmpdir):
     assert cmd.called
 
 
+@restore_environ(["DJANGO_SETTINGS_MODULE"])
 def test_main_from_setup_cfg(mocker, tmpdir):
     """Read settings module path from config file."""
     cmd = mocker.patch("django_cmd.execute_from_command_line")
@@ -59,9 +79,9 @@ def test_main_from_setup_cfg(mocker, tmpdir):
     main()
     assert os.environ.get("DJANGO_SETTINGS_MODULE") == "ball.yarn"
     assert cmd.called
-    del os.environ["DJANGO_SETTINGS_MODULE"]
 
 
+@restore_environ(["DJANGO_SETTINGS_MODULE"])
 def test_main_no_configfile(mocker, tmpdir):
     """Try to read settings module, but fail and still run command."""
     cmd = mocker.patch("django_cmd.execute_from_command_line")
@@ -71,6 +91,7 @@ def test_main_no_configfile(mocker, tmpdir):
     assert cmd.called
 
 
+@restore_environ(["DJANGO_SETTINGS_MODULE"])
 def test_new_project(tmpdir):
     """Should be able to use with a new project."""
     tmpdir.chdir()
@@ -78,3 +99,24 @@ def test_new_project(tmpdir):
     config = '[tool.django]\nsettings_module = "myproject.settings"\n'
     tmpdir.join("pyproject.toml").write(config.encode("utf-8"))
     subprocess.run(["django", "check"], check=True)
+
+
+@pytest.mark.skipif(
+    os.environ.get("TOX"),
+    reason="Doesn't release the port quickly enough to run multiple times in quick succession with tox.",
+)
+@restore_environ(["DJANGO_SETTINGS_MODULE"])
+def test_runserver(tmpdir):
+    """Should be able to run the development server for several seconds."""
+    tmpdir.chdir()
+    subprocess.run(["django", "startproject", "myproject", "."], check=True)
+    config = '[tool.django]\nsettings_module = "myproject.settings"\n'
+    tmpdir.join("pyproject.toml").write(config.encode("utf-8"))
+    with pytest.raises(subprocess.TimeoutExpired):
+        # Runserver starts a subprocess, but never exits.
+        # 1 second is not enough time for it to start and error
+        # if the settings module isn't configured correctly.
+        # 2 seems to be OK, but to make it hopefully more reliable
+        # we'll use 3 seconds. Otherwise this might not break even
+        # if the functionality does.
+        subprocess.run(["django", "runserver"], check=True, timeout=3)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "django-cmd"
-version = "2.1"
+version = "2.2"
 description = "Have a django command"
 authors = [{ name = "Ryan Hiebert", email = "ryan@ryanhiebert.com" }]
 license = "MIT"

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ envlist =
 [testenv]
 setenv =
     COVERAGE_PROCESS_START=.coveragerc
+    TOX=True
 dependency_groups = dev
 deps =
     dj22: Django~=2.2.0


### PR DESCRIPTION
In order to enable the runserver command, read the settings module from the file even if the environment variable is already set, and adjust the path if the environment variable matches the configuration.

This will fix #13 as well as #9, since the edge-case won't come up anymore when the DJANGO_SETTINGS_MODULE is set to the same as the config.