### PR TITLE
Add support to built-in django-admin command

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,3 +1,9 @@
+2.3 (2024-12-20)
+++++++++++++++++
+
+* Support configuration when using
+  the built-in ``django-admin`` command.
+
 2.2 (2024-12-19)
 ++++++++++++++++
 

--- a/django_cmd_test.py
+++ b/django_cmd_test.py
@@ -4,7 +4,7 @@ from contextlib import contextmanager
 
 import pytest
 
-from django_cmd import main
+from django_cmd import configure
 
 
 @contextmanager
@@ -21,95 +21,100 @@ def restore_environ(keys):
 
 
 @restore_environ(["DJANGO_SETTINGS_MODULE"])
-def test_main_passthru(monkeypatch, mocker, tmpdir):
+def test_configure_passthru(monkeypatch, tmpdir):
     """It shouldn't change a given DJANGO_SETTINGS_MODULE."""
-    cmd = mocker.patch("django_cmd.execute_from_command_line")
     monkeypatch.setenv("DJANGO_SETTINGS_MODULE", "spam.eggs")
     content = "[django]\nsettings_module = ball.yarn\n"
     tmpdir.chdir()
     tmpdir.join("setup.cfg").write(content.encode("utf-8"))
-    main()
+    configure()
     assert os.environ.get("DJANGO_SETTINGS_MODULE") == "spam.eggs"
-    assert cmd.called
 
 
 @restore_environ(["DJANGO_SETTINGS_MODULE"])
-def test_main_from_pyproject_toml(mocker, tmpdir):
+def test_configure_from_pyproject_toml(tmpdir):
     """Read settings module path from toml file."""
-    cmd = mocker.patch("django_cmd.execute_from_command_line")
     content = '[tool.django]\nsettings_module = "ball.yarn"\n'
     tmpdir.chdir()
     tmpdir.join("pyproject.toml").write(content.encode("utf-8"))
-    main()
+    configure()
     assert os.environ.get("DJANGO_SETTINGS_MODULE") == "ball.yarn"
-    assert cmd.called
 
 
 @restore_environ(["DJANGO_SETTINGS_MODULE"])
-def test_main_from_pyproject_toml_nosetting(mocker, tmpdir):
+def test_configure_from_pyproject_toml_nosetting(mocker, tmpdir):
     """Handle if there's a tool.django section with no settings module."""
-    cmd = mocker.patch("django_cmd.execute_from_command_line")
     content = '[tool.django]\nsomesetting = "notrelevant"\n'
     tmpdir.chdir()
     tmpdir.join("pyproject.toml").write(content.encode("utf-8"))
-    main()
+    configure()
     assert "DJANGO_SETTINGS_MODULE" not in os.environ
-    assert cmd.called
 
 
 @restore_environ(["DJANGO_SETTINGS_MODULE"])
-def test_main_from_pyproject_toml_nodjango(mocker, tmpdir):
+def test_main_from_pyproject_toml_nodjango(tmpdir):
     """Handle if there's no tool.django section."""
-    cmd = mocker.patch("django_cmd.execute_from_command_line")
     content = '[project]\nname = "ball"\n'
     tmpdir.chdir()
     tmpdir.join("pyproject.toml").write(content.encode("utf-8"))
-    main()
+    configure()
     assert "DJANGO_SETTINGS_MODULE" not in os.environ
-    assert cmd.called
 
 
 @restore_environ(["DJANGO_SETTINGS_MODULE"])
-def test_main_from_setup_cfg(mocker, tmpdir):
+def test_configure_from_setup_cfg(tmpdir):
     """Read settings module path from config file."""
-    cmd = mocker.patch("django_cmd.execute_from_command_line")
     content = "[django]\nsettings_module = ball.yarn\n"
     tmpdir.chdir()
     tmpdir.join("setup.cfg").write(content.encode("utf-8"))
-    main()
+    configure()
     assert os.environ.get("DJANGO_SETTINGS_MODULE") == "ball.yarn"
-    assert cmd.called
 
 
 @restore_environ(["DJANGO_SETTINGS_MODULE"])
-def test_main_no_configfile(mocker, tmpdir):
+def test_configure_no_configfile(tmpdir):
     """Try to read settings module, but fail and still run command."""
-    cmd = mocker.patch("django_cmd.execute_from_command_line")
     tmpdir.chdir()
-    main()
+    configure()
     assert "DJANGO_SETTINGS_MODULE" not in os.environ
-    assert cmd.called
 
 
 @restore_environ(["DJANGO_SETTINGS_MODULE"])
-def test_new_project(tmpdir):
-    """Should be able to use with a new project."""
+def test_check_with_script_target(tmpdir):
+    """Run check without a subprocess for coverage."""
+    from django.core.management import execute_from_command_line
+
     tmpdir.chdir()
     subprocess.run(["django", "startproject", "myproject", "."], check=True)
     config = '[tool.django]\nsettings_module = "myproject.settings"\n'
     tmpdir.join("pyproject.toml").write(config.encode("utf-8"))
-    subprocess.run(["django", "check"], check=True)
+
+    execute_from_command_line(["django", "check"])
+
+
+@pytest.mark.parametrize("command", ["django", "django-admin"])
+@restore_environ(["DJANGO_SETTINGS_MODULE"])
+def test_new_project(command, tmpdir):
+    """Should be able to use with a new project."""
+    tmpdir.chdir()
+    subprocess.run([command, "startproject", "myproject", "."], check=True)
+    config = '[tool.django]\nsettings_module = "myproject.settings"\n'
+    tmpdir.join("pyproject.toml").write(config.encode("utf-8"))
+    subprocess.run([command, "check"], check=True)
 
 
 @pytest.mark.skipif(
     os.environ.get("TOX"),
     reason="Doesn't release the port quickly enough to run multiple times in quick succession with tox.",
 )
+@pytest.mark.parametrize(
+    "command", ["django-admin"]
+)  # If django-admin works, so will django
 @restore_environ(["DJANGO_SETTINGS_MODULE"])
-def test_runserver(tmpdir):
+def test_runserver(command, tmpdir):
     """Should be able to run the development server for several seconds."""
     tmpdir.chdir()
-    subprocess.run(["django", "startproject", "myproject", "."], check=True)
+    subprocess.run([command, "startproject", "myproject", "."], check=True)
     config = '[tool.django]\nsettings_module = "myproject.settings"\n'
     tmpdir.join("pyproject.toml").write(config.encode("utf-8"))
     with pytest.raises(subprocess.TimeoutExpired):
@@ -119,4 +124,4 @@ def test_runserver(tmpdir):
         # 2 seems to be OK, but to make it hopefully more reliable
         # we'll use 3 seconds. Otherwise this might not break even
         # if the functionality does.
-        subprocess.run(["django", "runserver"], check=True, timeout=3)
+        subprocess.run([command, "runserver"], check=True, timeout=3)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "django-cmd"
-version = "2.2"
+version = "2.3"
 description = "Have a django command"
 authors = [{ name = "Ryan Hiebert", email = "ryan@ryanhiebert.com" }]
 license = "MIT"
@@ -40,7 +40,7 @@ homepage = "https://github.com/ryanhiebert/django-cmd"
 repository = "https://github.com/ryanhiebert/django-cmd"
 
 [project.scripts]
-django = "django_cmd:main"
+django = "django.core.management:execute_from_command_line"
 
 [build-system]
 requires = ["hatchling"]
@@ -52,3 +52,10 @@ dev = ["pytest", "pytest-mock", "coverage", "ruff", "isort"]
 [tool.coverage.run]
 branch = true
 source = "django_cmd"
+
+[tool.hatch.build.hooks.autorun]
+dependencies = ["hatch-autorun"]
+code = """
+import django_cmd
+django_cmd.patch_django()
+"""


### PR DESCRIPTION
Use hatch-autorun to hook into the django management command before it is run.

Notably, this monkeypatching requires that the module always be loaded, even if django itself isn't being loaded by a script. It may not be the biggest problem, but it is more heavy-handed than I'd like. I'd rather have the implementation only add a hook so that when the module is _imported_ it will be monkeypatched before it is fully imported.