### PR TITLE
Add the pyproject directory to the path

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,3 +1,9 @@
+2.6 (2025-01-10)
+++++++++++++++++
+
+* Use the ``pyproject.toml`` directory as the path
+  when discovered by walking up the tree.
+
 2.5 (2025-01-09)
 ++++++++++++++++
 

--- a/django_cmd.py
+++ b/django_cmd.py
@@ -23,15 +23,16 @@ def locate() -> Path:
 
 def configure():
     """Run Django, getting the default from a file if needed."""
-    settings_module = None
+    settings_module = path = None
 
     # Load from pyproject.toml first
     if pyproject := locate():
         with pyproject.open("rb") as f:
             config = tomllib.load(f)
-            settings_module = (
-                config.get("tool", {}).get("django", {}).get("settings_module")
-            )
+        settings_module = (
+            config.get("tool", {}).get("django", {}).get("settings_module")
+        )
+        path = None if settings_module is None else pyproject.parent
 
     if settings_module is None:
         # Try loading configuration from setup.cfg next
@@ -39,11 +40,12 @@ def configure():
         parser.read("setup.cfg")
         if parser.has_option("django", "settings_module"):
             settings_module = parser.get("django", "settings_module")
+            path = None if settings_module is None else Path.cwd()
 
-    if settings_module is not None:
+    if settings_module is not None and path is not None:
         os.environ.setdefault("DJANGO_SETTINGS_MODULE", settings_module)
         if settings_module == os.environ["DJANGO_SETTINGS_MODULE"]:
-            sys.path.insert(0, os.getcwd())
+            sys.path.insert(0, str(path))
 
 
 @wraps(django.core.management.ManagementUtility, updated=())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "django-cmd"
-version = "2.5"
+version = "2.6"
 description = "Have a django command"
 authors = [{ name = "Ryan Hiebert", email = "ryan@ryanhiebert.com" }]
 license = "MIT"


### PR DESCRIPTION
When walking up the tree to find the pyproject.toml, use the directory the pyproject.toml is in as the pythonpath rather than the current working directory.